### PR TITLE
fix: Redis `invalidate` not working when there is only 1 entry

### DIFF
--- a/src/providers/redis.ts
+++ b/src/providers/redis.ts
@@ -60,7 +60,7 @@ export class RedisCacheProvider implements CacheProvider {
             })
 
             stream.on('data', async (keys: string[]) => {
-              if (keys.length > 1) {
+              if (keys.length > 0) {
                 await this.redis.del(...keys)
               }
             })
@@ -81,7 +81,7 @@ export class RedisCacheProvider implements CacheProvider {
       })
 
       stream.on('data', async (keys: string[]) => {
-        if (keys.length > 1) {
+        if (keys.length > 0) {
           await this.redis.del(...keys)
         }
       })

--- a/tests/redis.test.ts
+++ b/tests/redis.test.ts
@@ -1191,4 +1191,40 @@ describe('Cache plugin (redis)', () => {
       }),
     ).resolves.toBe(true)
   })
+
+  it('invalidates correctly when there is only 1 entry', async () => {
+    let extDb = db.$use(
+      defineCachePlugin({
+        provider: new RedisCacheProvider({
+          url: process.env['REDIS_URL'] as string,
+        }),
+      }),
+    )
+
+    await extDb.user.create({
+      data: {
+        email: 'test@email.com',
+      },
+    })
+
+    await extDb.user.exists({
+      cache: {
+        tags: ['user1'],
+        ttl: 60,
+      },
+    })
+
+    await extDb.$cache.invalidate({
+      tags: ['user1'],
+    })
+
+    await extDb.user.exists({
+      cache: {
+        tags: ['user1'],
+        ttl: 60,
+      },
+    })
+
+    expect(extDb.$cache.status).toBe('miss')
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache invalidation so tagged and global invalidation removes matching entries even when only one cache entry exists.

* **Tests**
  * Added coverage to verify that invalidating a single cached entry correctly results in a cache miss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->